### PR TITLE
Include missing files in sdist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,2 @@
 include LICENSE
+include *.txt


### PR DESCRIPTION
Include missing files in sdist for #1

Tested with

```
++ mktemp -d
+ D=/tmp/tmp.UoNNONKvfG
+ trap 'rm -rf /tmp/tmp.UoNNONKvfG' EXIT
+ python -m venv /tmp/tmp.UoNNONKvfG
+ python setup.py sdist -d /tmp/tmp.UoNNONKvfG
running sdist
running egg_info
writing pyanom.egg-info/PKG-INFO
writing dependency_links to pyanom.egg-info/dependency_links.txt
writing requirements to pyanom.egg-info/requires.txt
writing top-level names to pyanom.egg-info/top_level.txt
reading manifest file 'pyanom.egg-info/SOURCES.txt'
reading manifest template 'MANIFEST.in'
writing manifest file 'pyanom.egg-info/SOURCES.txt'
running check
creating pyanom-0.0.1b1
creating pyanom-0.0.1b1/pyanom
creating pyanom-0.0.1b1/pyanom.egg-info
copying files to pyanom-0.0.1b1...
copying LICENSE -> pyanom-0.0.1b1
copying MANIFEST.in -> pyanom-0.0.1b1
copying README.rst -> pyanom-0.0.1b1
copying requirements.txt -> pyanom-0.0.1b1
copying setup.py -> pyanom-0.0.1b1
copying pyanom/__init__.py -> pyanom-0.0.1b1/pyanom
copying pyanom/density_ratio_estimation.py -> pyanom-0.0.1b1/pyanom
copying pyanom/outlier_detection.py -> pyanom-0.0.1b1/pyanom
copying pyanom/structure_learning.py -> pyanom-0.0.1b1/pyanom
copying pyanom/subspace_methods.py -> pyanom-0.0.1b1/pyanom
copying pyanom/utils.py -> pyanom-0.0.1b1/pyanom
copying pyanom.egg-info/PKG-INFO -> pyanom-0.0.1b1/pyanom.egg-info
copying pyanom.egg-info/SOURCES.txt -> pyanom-0.0.1b1/pyanom.egg-info
copying pyanom.egg-info/dependency_links.txt -> pyanom-0.0.1b1/pyanom.egg-info
copying pyanom.egg-info/requires.txt -> pyanom-0.0.1b1/pyanom.egg-info
copying pyanom.egg-info/top_level.txt -> pyanom-0.0.1b1/pyanom.egg-info
Writing pyanom-0.0.1b1/setup.cfg
Creating tar archive
removing 'pyanom-0.0.1b1' (and everything under it)
+ cd /
+ /tmp/tmp.UoNNONKvfG/bin/pip install /tmp/tmp.UoNNONKvfG/pyanom-0.0.1b1.tar.gz
Processing /tmp/tmp.UoNNONKvfG/pyanom-0.0.1b1.tar.gz
Collecting numpy (from pyanom==0.0.1b1)
  Using cached https://files.pythonhosted.org/packages/cf/5d/e8198f11dd73a91f7bde15ca88a2b78913fa2b416ae2dc2a6aeafcf4c63d/numpy-1.18.4-cp38-cp38-manylinux1_x86_64.whl
Collecting pandas (from pyanom==0.0.1b1)
  Using cached https://files.pythonhosted.org/packages/f5/10/40688389f5e234bde06aa84e6f3ccf5beea6269f57e2bef67866d3b43268/pandas-1.0.3-cp38-cp38-manylinux1_x86_64.whl
Collecting python-dateutil>=2.6.1 (from pandas->pyanom==0.0.1b1)
  Using cached https://files.pythonhosted.org/packages/d4/70/d60450c3dd48ef87586924207ae8907090de0b306af2bce5d134d78615cb/python_dateutil-2.8.1-py2.py3-none-any.whl
Collecting pytz>=2017.2 (from pandas->pyanom==0.0.1b1)
  Using cached https://files.pythonhosted.org/packages/4f/a4/879454d49688e2fad93e59d7d4efda580b783c745fd2ec2a3adf87b0808d/pytz-2020.1-py2.py3-none-any.whl
Collecting six>=1.5 (from python-dateutil>=2.6.1->pandas->pyanom==0.0.1b1)
  Using cached https://files.pythonhosted.org/packages/ee/ff/48bde5c0f013094d729fe4b0316ba2a24774b3ff1c52d924a8a4cb04078a/six-1.15.0-py2.py3-none-any.whl
Installing collected packages: numpy, six, python-dateutil, pytz, pandas, pyanom
  Running setup.py install for pyanom: started
    Running setup.py install for pyanom: finished with status 'done'
Successfully installed numpy-1.18.4 pandas-1.0.3 pyanom-0.0.1b1 python-dateutil-2.8.1 pytz-2020.1 six-1.15.0
WARNING: You are using pip version 19.2.3, however version 20.1.1 is available.
You should consider upgrading via the 'pip install --upgrade pip' command.
+ echo Success
Success
++ rm -rf /tmp/tmp.UoNNONKvfG
```
